### PR TITLE
Add client_id to API calls

### DIFF
--- a/lib/twitch.core.js
+++ b/lib/twitch.core.js
@@ -30,6 +30,7 @@
 
     if (authenticated) params.oauth_token = Twitch._config.session.token;
     if (options.verb) params._method = options.verb;
+    params.client_id = Twitch._config.clientId;
 
 
     // When using JSONP, any error response will have a


### PR DESCRIPTION
This change adds client_id to the Kraken API calls to account for new "Client-ID" header requirements. Since using client_id in the GET params works, this fixes JSONP calls.